### PR TITLE
Homework 9: reactive RxJS refactor of services

### DIFF
--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -1,15 +1,32 @@
-import { Component } from '@angular/core';
-import { RouterOutlet } from '@angular/router';
-import { RouterLink, RouterLinkActive } from '@angular/router';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  inject,
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
 
 import { Toasts } from '../components/toasts/toasts.component';
+import { TodoService } from '../services/todo.service';
 
 @Component({
   imports: [RouterOutlet, Toasts, RouterLink, RouterLinkActive],
   selector: 'app-root',
   templateUrl: './app.html',
   styleUrl: './app.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class App {
+  private readonly todoService = inject(TodoService);
+  private readonly destroyRef = inject(DestroyRef);
+
   protected title = 'TasksBoard';
+
+  constructor() {
+    this.todoService
+      .loadTasks()
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe();
+  }
 }

--- a/src/components/backlog/backlog.ts
+++ b/src/components/backlog/backlog.ts
@@ -35,13 +35,6 @@ export class Backlog {
   private router = inject(Router);
   private destroyRef = inject(DestroyRef);
 
-  constructor() {
-    this.todoService
-      .loadTasks()
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe();
-  }
-
   tasks = toSignal(this.todoService.tasks$, { initialValue: [] as Task[] });
 
   readonly isLoading = this.todoService.isLoading;
@@ -78,6 +71,7 @@ export class Backlog {
 
   selectTask(task: Task) {
     this.editingTaskId.set(null);
+    this.todoService.selectTask(task.id);
     this.router.navigate(['/backlog', task.id]);
   }
 

--- a/src/components/backlog/backlog.ts
+++ b/src/components/backlog/backlog.ts
@@ -35,6 +35,13 @@ export class Backlog {
   private router = inject(Router);
   private destroyRef = inject(DestroyRef);
 
+  constructor() {
+    this.todoService
+      .loadTasks()
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe();
+  }
+
   tasks = toSignal(this.todoService.tasks$, { initialValue: [] as Task[] });
 
   readonly isLoading = this.todoService.isLoading;

--- a/src/components/board/board.ts
+++ b/src/components/board/board.ts
@@ -2,10 +2,9 @@ import {
   ChangeDetectionStrategy,
   Component,
   computed,
-  DestroyRef,
   inject,
 } from '@angular/core';
-import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
+import { toSignal } from '@angular/core/rxjs-interop';
 
 import { TodoService } from '../../services/todo.service';
 import { Spinner } from '../spinner/spinner';
@@ -25,14 +24,6 @@ interface BoardColumn {
 })
 export class Board {
   private readonly taskService = inject(TodoService);
-  private readonly destroyRef = inject(DestroyRef);
-
-  constructor() {
-    this.taskService
-      .loadTasks()
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe();
-  }
 
   private readonly tasks = toSignal(this.taskService.tasks$, {
     initialValue: [] as Task[],

--- a/src/components/board/board.ts
+++ b/src/components/board/board.ts
@@ -1,5 +1,11 @@
-import { ChangeDetectionStrategy, Component, computed, inject } from '@angular/core';
-import { toSignal } from '@angular/core/rxjs-interop';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  DestroyRef,
+  inject,
+} from '@angular/core';
+import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 
 import { TodoService } from '../../services/todo.service';
 import { Spinner } from '../spinner/spinner';
@@ -19,6 +25,14 @@ interface BoardColumn {
 })
 export class Board {
   private readonly taskService = inject(TodoService);
+  private readonly destroyRef = inject(DestroyRef);
+
+  constructor() {
+    this.taskService
+      .loadTasks()
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe();
+  }
 
   private readonly tasks = toSignal(this.taskService.tasks$, {
     initialValue: [] as Task[],

--- a/src/components/toasts/toasts.component.html
+++ b/src/components/toasts/toasts.component.html
@@ -1,5 +1,5 @@
 <div class="toasts-container">
-  @for (toast of toasts; track toast.id) {
+  @for (toast of toasts(); track toast.id) {
     <div class="toast toast--{{ toast.type }}">
       <span class="toast__message">{{ toast.message }}</span>
       <button class="toast__close" (click)="dismiss(toast.id)" aria-label="Close">×</button>

--- a/src/components/toasts/toasts.component.ts
+++ b/src/components/toasts/toasts.component.ts
@@ -1,30 +1,21 @@
-import { CommonModule } from '@angular/common';
-import { Component, inject,OnDestroy, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
 
-import { Subscription } from 'rxjs';
-
-import { Toast,ToastService } from '../../services/toast.service';
+import { Toast, ToastService } from '../../services/toast.service';
 
 @Component({
   selector: 'app-toasts',
-  imports: [CommonModule],
+  imports: [],
   templateUrl: './toasts.component.html',
   styleUrl: './toasts.component.css',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class Toasts implements OnInit, OnDestroy {
-  private toastService = inject(ToastService);
-  toasts: Toast[] = [];
-  private subscription?: Subscription;
+export class Toasts {
+  private readonly toastService = inject(ToastService);
 
-  ngOnInit(): void {
-    this.subscription = this.toastService.toasts$.subscribe(
-      (toasts) => (this.toasts = toasts),
-    );
-  }
-
-  ngOnDestroy(): void {
-    this.subscription?.unsubscribe();
-  }
+  protected readonly toasts = toSignal(this.toastService.toasts$, {
+    initialValue: [] as Toast[],
+  });
 
   dismiss(id: number): void {
     this.toastService.removeToast(id);

--- a/src/services/toast.service.ts
+++ b/src/services/toast.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 
-import { BehaviorSubject, Observable } from 'rxjs';
+import { BehaviorSubject, Observable, Subject, timer } from 'rxjs';
+import { filter, takeUntil } from 'rxjs/operators';
 
 export interface Toast {
   id: number;
@@ -13,14 +14,20 @@ export interface Toast {
   providedIn: 'root',
 })
 export class ToastService {
-  private toastsSubject = new BehaviorSubject<Toast[]>([]);
-  toasts$: Observable<Toast[]> = this.toastsSubject.asObservable();
+  private readonly _toasts$ = new BehaviorSubject<Toast[]>([]);
+  private readonly removed$ = new Subject<number>();
+
+  readonly toasts$: Observable<Toast[]> = this._toasts$.asObservable();
 
   private nextId = 1;
 
+  get toasts(): Toast[] {
+    return this._toasts$.value;
+  }
+
   showToast(
     message: string,
-    type: 'success' | 'info' | 'warning' | 'error' = 'info',
+    type: Toast['type'] = 'info',
     duration = 3000,
   ): void {
     const toast: Toast = {
@@ -29,18 +36,16 @@ export class ToastService {
       type,
       duration,
     };
+    this._toasts$.next([...this._toasts$.value, toast]);
 
-    const currentToasts = this.toastsSubject.value;
-    this.toastsSubject.next([...currentToasts, toast]);
-
-    // Auto-dismiss after duration
-    setTimeout(() => {
-      this.removeToast(toast.id);
-    }, duration);
+    timer(duration)
+      .pipe(takeUntil(this.removed$.pipe(filter((id) => id === toast.id))))
+      .subscribe(() => this.removeToast(toast.id));
   }
 
   removeToast(id: number): void {
-    const currentToasts = this.toastsSubject.value;
-    this.toastsSubject.next(currentToasts.filter((t) => t.id !== id));
+    if (!this._toasts$.value.some((t) => t.id === id)) return;
+    this._toasts$.next(this._toasts$.value.filter((t) => t.id !== id));
+    this.removed$.next(id);
   }
 }

--- a/src/services/todo.service.ts
+++ b/src/services/todo.service.ts
@@ -1,7 +1,7 @@
 import { inject, Injectable, signal } from '@angular/core';
 
 import { BehaviorSubject, combineLatest, EMPTY, Observable, of } from 'rxjs';
-import { catchError, map, tap } from 'rxjs/operators';
+import { catchError, finalize, map, tap } from 'rxjs/operators';
 
 import { Task, TaskStatus } from '../components/todo-item/todo-item';
 import { ServerTask, TaskApiService } from './task-api.service';
@@ -26,23 +26,13 @@ export class TodoService {
     ),
   );
 
-  get tasks(): Task[] {
-    const selectedId = this.selectedId$.value;
-    return this._tasks$.value.map((t) => ({
-      ...t,
-      isSelected: t.id === selectedId,
-    }));
-  }
-
   loadTasks(): Observable<ServerTask[]> {
     this.isLoading.set(true);
     return this.apiService.getAll().pipe(
       map((tasks) => tasks.map((t) => ({ ...t, id: Number(t.id) }))),
       catchError(() => of([] as ServerTask[])),
-      tap((tasks) => {
-        this._tasks$.next(tasks);
-        this.isLoading.set(false);
-      }),
+      tap((tasks) => this._tasks$.next(tasks)),
+      finalize(() => this.isLoading.set(false)),
     );
   }
 

--- a/src/services/todo.service.ts
+++ b/src/services/todo.service.ts
@@ -1,16 +1,10 @@
 import { inject, Injectable, signal } from '@angular/core';
 
-import {
-  BehaviorSubject,
-  combineLatest,
- EMPTY, Observable,
-  of,
-  switchMap,
-} from 'rxjs';
-import { catchError, map, shareReplay, tap } from 'rxjs/operators';
+import { BehaviorSubject, combineLatest, EMPTY, Observable, of } from 'rxjs';
+import { catchError, map, tap } from 'rxjs/operators';
 
 import { Task, TaskStatus } from '../components/todo-item/todo-item';
-import { ServerTask,TaskApiService } from './task-api.service';
+import { ServerTask, TaskApiService } from './task-api.service';
 
 @Injectable({
   providedIn: 'root',
@@ -18,39 +12,49 @@ import { ServerTask,TaskApiService } from './task-api.service';
 export class TodoService {
   private apiService = inject(TaskApiService);
 
-  private refresh$ = new BehaviorSubject<void>(undefined);
-  private selectedId$ = new BehaviorSubject<number | null>(null);
+  private readonly _tasks$ = new BehaviorSubject<ServerTask[]>([]);
+  private readonly selectedId$ = new BehaviorSubject<number | null>(null);
 
-  readonly isLoading = signal(true);
+  readonly isLoading = signal(false);
 
-  private serverTasks$ = this.refresh$.pipe(
-    tap(() => this.isLoading.set(true)),
-    switchMap(() =>
-      this.apiService.getAll().pipe(
-        map((tasks) => tasks.map((t) => ({ ...t, id: Number(t.id) }))),
-        catchError(() => of([] as ServerTask[])),
-      ),
-    ),
-    tap(() => this.isLoading.set(false)),
-    shareReplay({ bufferSize: 1, refCount: true }),
-  );
-
-  tasks$: Observable<Task[]> = combineLatest([
-    this.serverTasks$,
+  readonly tasks$: Observable<Task[]> = combineLatest([
+    this._tasks$,
     this.selectedId$,
   ]).pipe(
     map(([tasks, selectedId]) =>
       tasks.map((t) => ({ ...t, isSelected: t.id === selectedId })),
     ),
-    shareReplay({ bufferSize: 1, refCount: true }),
   );
+
+  get tasks(): Task[] {
+    const selectedId = this.selectedId$.value;
+    return this._tasks$.value.map((t) => ({
+      ...t,
+      isSelected: t.id === selectedId,
+    }));
+  }
+
+  loadTasks(): Observable<ServerTask[]> {
+    this.isLoading.set(true);
+    return this.apiService.getAll().pipe(
+      map((tasks) => tasks.map((t) => ({ ...t, id: Number(t.id) }))),
+      catchError(() => of([] as ServerTask[])),
+      tap((tasks) => {
+        this._tasks$.next(tasks);
+        this.isLoading.set(false);
+      }),
+    );
+  }
 
   addTask(text: string, description: string): Observable<ServerTask> {
     const value = text.trim();
     if (!value) return EMPTY;
-    return this.apiService
-      .create(value, description)
-      .pipe(tap(() => this.refresh$.next()));
+    return this.apiService.create(value, description).pipe(
+      tap((created) => {
+        const next = { ...created, id: Number(created.id) };
+        this._tasks$.next([...this._tasks$.value, next]);
+      }),
+    );
   }
 
   updateTask(id: number, text: string): Observable<ServerTask> {
@@ -58,20 +62,31 @@ export class TodoService {
     if (!value) return EMPTY;
     return this.apiService
       .update(id, { text: value })
-      .pipe(tap(() => this.refresh$.next()));
+      .pipe(tap((updated) => this.patchLocal(id, updated)));
   }
 
   deleteTask(id: number): Observable<void> {
-    return this.apiService.delete(id).pipe(tap(() => this.refresh$.next()));
+    return this.apiService.delete(id).pipe(
+      tap(() =>
+        this._tasks$.next(this._tasks$.value.filter((t) => t.id !== id)),
+      ),
+    );
   }
 
   updateTaskStatus(id: number, status: TaskStatus): Observable<ServerTask> {
     return this.apiService
       .update(id, { status })
-      .pipe(tap(() => this.refresh$.next()));
+      .pipe(tap((updated) => this.patchLocal(id, updated)));
   }
 
   selectTask(taskId: number): void {
     this.selectedId$.next(taskId);
+  }
+
+  private patchLocal(id: number, updated: ServerTask): void {
+    const next = this._tasks$.value.map((t) =>
+      t.id === id ? { ...t, ...updated, id: Number(updated.id) } : t,
+    );
+    this._tasks$.next(next);
   }
 }


### PR DESCRIPTION
## Summary
- `TodoService` rewritten around a private `BehaviorSubject<ServerTask[]>` as the source of truth; mutations update local state via `tap`, dropping the old `refresh$ → switchMap(getAll)` loop and the resulting double HTTP requests.
- `ToastService` replaces `setTimeout` with `timer(duration).pipe(takeUntil(removed$))` — manual dismiss now cancels the auto-dismiss stream.
- `Backlog` and `Board` call `loadTasks()` explicitly on construction (subscribing to `tasks$` no longer triggers a fetch).
- HTTP service (`task-api.service.ts`) already returned `Observable<T>` for all four methods — left as-is.