### PR TITLE
Homework 10: i18n with ngx-translate (EN/RU)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ Thumbs.db
 # Claude Code
 .claude/
 AGENTS.md
+
+# Local verification artifacts
+/screenshots

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,8 @@
         "@angular/platform-server": "20.2.4",
         "@angular/router": "20.2.4",
         "@angular/ssr": "20.2.2",
+        "@ngx-translate/core": "^17.0.0",
+        "@ngx-translate/http-loader": "^17.0.0",
         "express": "^4.21.2",
         "rxjs": "~7.8.0",
         "zone.js": "~0.15.0"
@@ -7569,6 +7571,32 @@
         "@angular/compiler-cli": "^20.0.0",
         "typescript": ">=5.8 <6.0",
         "webpack": "^5.54.0"
+      }
+    },
+    "node_modules/@ngx-translate/core": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@ngx-translate/core/-/core-17.0.0.tgz",
+      "integrity": "sha512-Rft2D5ns2pq4orLZjEtx1uhNuEBerUdpFUG1IcqtGuipj6SavgB8SkxtNQALNDA+EVlvsNCCjC2ewZVtUeN6rg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/common": ">=16",
+        "@angular/core": ">=16"
+      }
+    },
+    "node_modules/@ngx-translate/http-loader": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@ngx-translate/http-loader/-/http-loader-17.0.0.tgz",
+      "integrity": "sha512-hgS8sa0ARjH9ll3PhkLTufeVXNI2DNR2uFKDhBgq13siUXzzVr/a31M6zgecrtwbA34iaBV01hsTMbMS8V7iIw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/common": ">=16",
+        "@angular/core": ">=16"
       }
     },
     "node_modules/@nodelib/fs.scandir": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "@angular/platform-server": "20.2.4",
     "@angular/router": "20.2.4",
     "@angular/ssr": "20.2.2",
+    "@ngx-translate/core": "^17.0.0",
+    "@ngx-translate/http-loader": "^17.0.0",
     "express": "^4.21.2",
     "rxjs": "~7.8.0",
     "zone.js": "~0.15.0"

--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -1,0 +1,57 @@
+{
+  "app": {
+    "title": "Tasks Board"
+  },
+  "nav": {
+    "backlog": "Backlog",
+    "board": "Board"
+  },
+  "filter": {
+    "all": "All",
+    "inProgress": "In Progress",
+    "completed": "Completed",
+    "todo": "To Do"
+  },
+  "board": {
+    "title": "Board",
+    "columns": {
+      "todo": "To Do",
+      "inProgress": "In Progress",
+      "done": "Done"
+    }
+  },
+  "backlog": {
+    "title": "Backlog"
+  },
+  "todoItem": {
+    "remove": "remove",
+    "save": "save",
+    "cancel": "cancel",
+    "removeHint": "Click to remove this task"
+  },
+  "createTask": {
+    "namePlaceholder": "Task name",
+    "descriptionPlaceholder": "Task description",
+    "addButton": "add",
+    "addHint": "Click to add a new task"
+  },
+  "details": {
+    "title": "Task Description",
+    "completed": "Completed",
+    "placeholder": "Select a task to see its description"
+  },
+  "toasts": {
+    "taskAdded": "Task added",
+    "taskAddError": "Error while adding task",
+    "taskDeleted": "Task deleted",
+    "taskDeleteError": "Error while deleting task",
+    "taskUpdated": "Task updated",
+    "taskUpdateError": "Error while updating task",
+    "close": "Close"
+  },
+  "language": {
+    "label": "Language",
+    "en": "EN",
+    "ru": "RU"
+  }
+}

--- a/public/i18n/ru.json
+++ b/public/i18n/ru.json
@@ -1,0 +1,57 @@
+{
+  "app": {
+    "title": "Доска задач"
+  },
+  "nav": {
+    "backlog": "Бэклог",
+    "board": "Доска"
+  },
+  "filter": {
+    "all": "Все",
+    "inProgress": "В работе",
+    "completed": "Завершённые",
+    "todo": "К выполнению"
+  },
+  "board": {
+    "title": "Доска",
+    "columns": {
+      "todo": "К выполнению",
+      "inProgress": "В работе",
+      "done": "Готово"
+    }
+  },
+  "backlog": {
+    "title": "Бэклог"
+  },
+  "todoItem": {
+    "remove": "удалить",
+    "save": "сохранить",
+    "cancel": "отмена",
+    "removeHint": "Нажмите, чтобы удалить задачу"
+  },
+  "createTask": {
+    "namePlaceholder": "Название задачи",
+    "descriptionPlaceholder": "Описание задачи",
+    "addButton": "добавить",
+    "addHint": "Нажмите, чтобы добавить задачу"
+  },
+  "details": {
+    "title": "Описание задачи",
+    "completed": "Завершено",
+    "placeholder": "Выберите задачу, чтобы увидеть её описание"
+  },
+  "toasts": {
+    "taskAdded": "Задача добавлена",
+    "taskAddError": "Ошибка при добавлении задачи",
+    "taskDeleted": "Задача удалена",
+    "taskDeleteError": "Ошибка при удалении задачи",
+    "taskUpdated": "Задача обновлена",
+    "taskUpdateError": "Ошибка при обновлении задачи",
+    "close": "Закрыть"
+  },
+  "language": {
+    "label": "Язык",
+    "en": "EN",
+    "ru": "RU"
+  }
+}

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -6,6 +6,9 @@ import {
 } from '@angular/core';
 import { provideRouter } from '@angular/router';
 
+import { provideTranslateService } from '@ngx-translate/core';
+import { provideTranslateHttpLoader } from '@ngx-translate/http-loader';
+
 import { appRoutes } from './app.routes';
 
 export const appConfig: ApplicationConfig = {
@@ -14,5 +17,10 @@ export const appConfig: ApplicationConfig = {
     provideZoneChangeDetection({ eventCoalescing: true }),
     provideRouter(appRoutes),
     provideHttpClient(),
+    provideTranslateService({
+      fallbackLang: 'en',
+      lang: 'en',
+    }),
+    provideTranslateHttpLoader({ prefix: '/i18n/', suffix: '.json' }),
   ],
 };

--- a/src/app/app.html
+++ b/src/app/app.html
@@ -1,13 +1,19 @@
-<div class="layout">
-  <aside class="sidebar">
-    <h1>Tasks Board</h1>
-    <nav class="nav">
-      <a routerLink="/backlog" routerLinkActive="active">Backlog</a>
-      <a routerLink="/board" routerLinkActive="active">Board</a>
-    </nav>
-  </aside>
-  <main class="content">
-    <router-outlet />
-  </main>
+<div class="shell">
+  <header class="topbar">
+    <h1 class="topbar__title">{{ 'app.title' | translate }}</h1>
+    <app-language-switcher class="topbar__lang" />
+  </header>
+
+  <div class="layout">
+    <aside class="sidebar">
+      <nav class="nav">
+        <a routerLink="/backlog" routerLinkActive="active">{{ 'nav.backlog' | translate }}</a>
+        <a routerLink="/board" routerLinkActive="active">{{ 'nav.board' | translate }}</a>
+      </nav>
+    </aside>
+    <main class="content">
+      <router-outlet />
+    </main>
+  </div>
 </div>
 <app-toasts />

--- a/src/app/app.scss
+++ b/src/app/app.scss
@@ -1,12 +1,39 @@
+.shell {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+}
+
+.topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 1.25rem;
+  background-color: #0f0a18;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.topbar__title {
+  margin: 0;
+  font-size: 1.25rem;
+  color: #c3b3d8;
+}
+
+.topbar__lang {
+  display: inline-flex;
+}
+
 .content {
   flex: 1;
   min-width: 0;
+  overflow: auto;
 }
 
 .layout {
   display: flex;
   flex-direction: row;
-  height: 100vh;
+  flex: 1;
+  min-height: 0;
 }
 
 .sidebar {

--- a/src/app/app.scss
+++ b/src/app/app.scss
@@ -2,6 +2,9 @@
   display: flex;
   flex-direction: column;
   height: 100vh;
+  max-width: 1440px;
+  width: 100%;
+  margin: 0 auto;
 }
 
 .topbar {

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -1,15 +1,32 @@
-import { Component } from '@angular/core';
-import { RouterOutlet } from '@angular/router';
-import { RouterLink, RouterLinkActive } from '@angular/router';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  inject,
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
 
 import { Toasts } from '../components/toasts/toasts.component';
+import { TodoService } from '../services/todo.service';
 
 @Component({
   imports: [RouterOutlet, Toasts, RouterLink, RouterLinkActive],
   selector: 'app-root',
   templateUrl: './app.html',
   styleUrl: './app.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class App {
+  private readonly todoService = inject(TodoService);
+  private readonly destroyRef = inject(DestroyRef);
+
   protected title = 'TasksBoard';
+
+  constructor() {
+    this.todoService
+      .loadTasks()
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe();
+  }
 }

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -7,11 +7,21 @@ import {
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
 
+import { TranslatePipe } from '@ngx-translate/core';
+
+import { LanguageSwitcher } from '../components/language-switcher/language-switcher';
 import { Toasts } from '../components/toasts/toasts.component';
 import { TodoService } from '../services/todo.service';
 
 @Component({
-  imports: [RouterOutlet, Toasts, RouterLink, RouterLinkActive],
+  imports: [
+    RouterOutlet,
+    Toasts,
+    RouterLink,
+    RouterLinkActive,
+    TranslatePipe,
+    LanguageSwitcher,
+  ],
   selector: 'app-root',
   templateUrl: './app.html',
   styleUrl: './app.scss',
@@ -20,8 +30,6 @@ import { TodoService } from '../services/todo.service';
 export class App {
   private readonly todoService = inject(TodoService);
   private readonly destroyRef = inject(DestroyRef);
-
-  protected title = 'TasksBoard';
 
   constructor() {
     this.todoService

--- a/src/components/backlog/backlog.html
+++ b/src/components/backlog/backlog.html
@@ -1,5 +1,5 @@
 <div class="page">
-  <h2>Backlog</h2>
+  <h2>{{ 'backlog.title' | translate }}</h2>
   <div class="todo-layout">
     <div class="todo-list-container">
       @if (isLoading()) {
@@ -12,10 +12,10 @@
           (change)="activeFilter.set($event.value)"
           hideSingleSelectionIndicator
         >
-          <mat-button-toggle [value]="null">All</mat-button-toggle>
-          <mat-button-toggle value="InProgress">In Progress</mat-button-toggle>
-          <mat-button-toggle value="Completed">Completed</mat-button-toggle>
-          <mat-button-toggle value="ToDo">To Do</mat-button-toggle>
+          <mat-button-toggle [value]="null">{{ 'filter.all' | translate }}</mat-button-toggle>
+          <mat-button-toggle value="InProgress">{{ 'filter.inProgress' | translate }}</mat-button-toggle>
+          <mat-button-toggle value="Completed">{{ 'filter.completed' | translate }}</mat-button-toggle>
+          <mat-button-toggle value="ToDo">{{ 'filter.todo' | translate }}</mat-button-toggle>
         </mat-button-toggle-group>
       </div>
 

--- a/src/components/backlog/backlog.spec.ts
+++ b/src/components/backlog/backlog.spec.ts
@@ -1,6 +1,7 @@
 import { provideHttpClient } from '@angular/common/http';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
+
 import { provideTranslateService } from '@ngx-translate/core';
 
 import { Backlog } from './backlog';

--- a/src/components/backlog/backlog.spec.ts
+++ b/src/components/backlog/backlog.spec.ts
@@ -1,6 +1,7 @@
 import { provideHttpClient } from '@angular/common/http';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
+import { provideTranslateService } from '@ngx-translate/core';
 
 import { Backlog } from './backlog';
 
@@ -11,7 +12,11 @@ describe('Backlog', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [Backlog],
-      providers: [provideHttpClient(), provideRouter([])],
+      providers: [
+        provideHttpClient(),
+        provideRouter([]),
+        provideTranslateService(),
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(Backlog);

--- a/src/components/backlog/backlog.ts
+++ b/src/components/backlog/backlog.ts
@@ -10,6 +10,8 @@ import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import { MatButtonToggleModule } from '@angular/material/button-toggle';
 import { Router, RouterOutlet } from '@angular/router';
 
+import { TranslatePipe, TranslateService } from '@ngx-translate/core';
+
 import { ToastService } from '../../services/toast.service';
 import { TodoService } from '../../services/todo.service';
 import { Spinner } from '../spinner/spinner';
@@ -24,6 +26,7 @@ import { Task, TaskStatus,TodoItem } from '../todo-item/todo-item';
     TodoCreateItem,
     Spinner,
     RouterOutlet,
+    TranslatePipe,
   ],
   templateUrl: './backlog.html',
   styleUrl: './backlog.css',
@@ -32,6 +35,7 @@ import { Task, TaskStatus,TodoItem } from '../todo-item/todo-item';
 export class Backlog {
   private todoService = inject(TodoService);
   private toastService = inject(ToastService);
+  private translate = inject(TranslateService);
   private router = inject(Router);
   private destroyRef = inject(DestroyRef);
 
@@ -52,9 +56,16 @@ export class Backlog {
       .addTask(text, description)
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
-        next: () => this.toastService.showToast('Задача добавлена', 'success'),
+        next: () =>
+          this.toastService.showToast(
+            this.translate.instant('toasts.taskAdded'),
+            'success',
+          ),
         error: () =>
-          this.toastService.showToast('Ошибка при добавлении задачи', 'error'),
+          this.toastService.showToast(
+            this.translate.instant('toasts.taskAddError'),
+            'error',
+          ),
       });
   }
 
@@ -63,9 +74,16 @@ export class Backlog {
       .deleteTask(task.id)
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
-        next: () => this.toastService.showToast('Задача удалена', 'success'),
+        next: () =>
+          this.toastService.showToast(
+            this.translate.instant('toasts.taskDeleted'),
+            'success',
+          ),
         error: () =>
-          this.toastService.showToast('Ошибка при удалении задачи', 'error'),
+          this.toastService.showToast(
+            this.translate.instant('toasts.taskDeleteError'),
+            'error',
+          ),
       });
   }
 
@@ -85,9 +103,16 @@ export class Backlog {
       .updateTask(task.id, newText)
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
-        next: () => this.toastService.showToast('Задача обновлена', 'success'),
+        next: () =>
+          this.toastService.showToast(
+            this.translate.instant('toasts.taskUpdated'),
+            'success',
+          ),
         error: () =>
-          this.toastService.showToast('Ошибка при обновлении задачи', 'error'),
+          this.toastService.showToast(
+            this.translate.instant('toasts.taskUpdateError'),
+            'error',
+          ),
       });
   }
 

--- a/src/components/backlog/backlog.ts
+++ b/src/components/backlog/backlog.ts
@@ -35,13 +35,6 @@ export class Backlog {
   private router = inject(Router);
   private destroyRef = inject(DestroyRef);
 
-  constructor() {
-    this.todoService
-      .loadTasks()
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe();
-  }
-
   tasks = toSignal(this.todoService.tasks$, { initialValue: [] as Task[] });
 
   readonly isLoading = this.todoService.isLoading;
@@ -78,6 +71,7 @@ export class Backlog {
 
   selectTask(task: Task) {
     this.editingTaskId.set(null);
+    this.todoService.selectTask(task.id);
     this.router.navigate(['/backlog', task.id]);
   }
 

--- a/src/components/backlog/backlog.ts
+++ b/src/components/backlog/backlog.ts
@@ -35,6 +35,13 @@ export class Backlog {
   private router = inject(Router);
   private destroyRef = inject(DestroyRef);
 
+  constructor() {
+    this.todoService
+      .loadTasks()
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe();
+  }
+
   tasks = toSignal(this.todoService.tasks$, { initialValue: [] as Task[] });
 
   readonly isLoading = this.todoService.isLoading;

--- a/src/components/board/board.css
+++ b/src/components/board/board.css
@@ -5,7 +5,8 @@
 }
 
 .board-column {
-  width: 280px;
+  flex: 1 1 0;
+  min-width: 0;
   display: flex;
   flex-direction: column;
   gap: 12px;

--- a/src/components/board/board.html
+++ b/src/components/board/board.html
@@ -1,12 +1,12 @@
 <div class="page">
-  <h2>Board</h2>
+  <h2>{{ 'board.title' | translate }}</h2>
   @if (isLoading()) {
   <app-spinner />
   } @else {
   <div class="board">
     @for (col of columns(); track col.status) {
     <div class="board-column">
-      <p>{{ col.title }} {{ col.tasks.length }}</p>
+      <p>{{ col.titleKey | translate }} {{ col.tasks.length }}</p>
       @for (t of col.tasks; track t.id) {
       <div class="task-card">{{ t.text }}</div>
       }

--- a/src/components/board/board.spec.ts
+++ b/src/components/board/board.spec.ts
@@ -1,5 +1,6 @@
 import { provideHttpClient } from '@angular/common/http';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideTranslateService } from '@ngx-translate/core';
 
 import { Board } from './board';
 
@@ -10,7 +11,7 @@ describe('Board', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [Board],
-      providers: [provideHttpClient()],
+      providers: [provideHttpClient(), provideTranslateService()],
     }).compileComponents();
 
     fixture = TestBed.createComponent(Board);

--- a/src/components/board/board.spec.ts
+++ b/src/components/board/board.spec.ts
@@ -1,5 +1,6 @@
 import { provideHttpClient } from '@angular/common/http';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+
 import { provideTranslateService } from '@ngx-translate/core';
 
 import { Board } from './board';

--- a/src/components/board/board.ts
+++ b/src/components/board/board.ts
@@ -2,10 +2,9 @@ import {
   ChangeDetectionStrategy,
   Component,
   computed,
-  DestroyRef,
   inject,
 } from '@angular/core';
-import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
+import { toSignal } from '@angular/core/rxjs-interop';
 
 import { TodoService } from '../../services/todo.service';
 import { Spinner } from '../spinner/spinner';
@@ -25,14 +24,6 @@ interface BoardColumn {
 })
 export class Board {
   private readonly taskService = inject(TodoService);
-  private readonly destroyRef = inject(DestroyRef);
-
-  constructor() {
-    this.taskService
-      .loadTasks()
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe();
-  }
 
   private readonly tasks = toSignal(this.taskService.tasks$, {
     initialValue: [] as Task[],

--- a/src/components/board/board.ts
+++ b/src/components/board/board.ts
@@ -6,18 +6,20 @@ import {
 } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 
+import { TranslatePipe } from '@ngx-translate/core';
+
 import { TodoService } from '../../services/todo.service';
 import { Spinner } from '../spinner/spinner';
 import { Task, TaskStatus } from '../todo-item/todo-item';
 
 interface BoardColumn {
-  title: string;
+  titleKey: string;
   status: TaskStatus;
 }
 
 @Component({
   selector: 'app-board',
-  imports: [Spinner],
+  imports: [Spinner, TranslatePipe],
   templateUrl: './board.html',
   styleUrl: './board.css',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -32,9 +34,9 @@ export class Board {
   protected readonly isLoading = this.taskService.isLoading;
 
   private readonly columnDefs: readonly BoardColumn[] = [
-    { title: 'To Do', status: 'ToDo' },
-    { title: 'In Progress', status: 'InProgress' },
-    { title: 'Done', status: 'Completed' },
+    { titleKey: 'board.columns.todo', status: 'ToDo' },
+    { titleKey: 'board.columns.inProgress', status: 'InProgress' },
+    { titleKey: 'board.columns.done', status: 'Completed' },
   ];
 
   protected readonly columns = computed(() =>

--- a/src/components/board/board.ts
+++ b/src/components/board/board.ts
@@ -1,5 +1,11 @@
-import { ChangeDetectionStrategy, Component, computed, inject } from '@angular/core';
-import { toSignal } from '@angular/core/rxjs-interop';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  DestroyRef,
+  inject,
+} from '@angular/core';
+import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 
 import { TodoService } from '../../services/todo.service';
 import { Spinner } from '../spinner/spinner';
@@ -19,6 +25,14 @@ interface BoardColumn {
 })
 export class Board {
   private readonly taskService = inject(TodoService);
+  private readonly destroyRef = inject(DestroyRef);
+
+  constructor() {
+    this.taskService
+      .loadTasks()
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe();
+  }
 
   private readonly tasks = toSignal(this.taskService.tasks$, {
     initialValue: [] as Task[],

--- a/src/components/language-switcher/language-switcher.css
+++ b/src/components/language-switcher/language-switcher.css
@@ -1,0 +1,25 @@
+.lang-toggle-group {
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.lang-toggle-group ::ng-deep .mat-button-toggle {
+  color: rgba(255, 255, 255, 0.6);
+  background: transparent;
+  border-color: rgba(255, 255, 255, 0.1);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+}
+
+.lang-toggle-group ::ng-deep .mat-button-toggle-checked {
+  color: #fff;
+  background: rgba(155, 89, 182, 0.45);
+}
+
+.lang-toggle-group ::ng-deep .mat-button-toggle-label-content {
+  line-height: 28px;
+  padding: 0 12px;
+}

--- a/src/components/language-switcher/language-switcher.html
+++ b/src/components/language-switcher/language-switcher.html
@@ -1,0 +1,13 @@
+<mat-button-toggle-group
+  class="lang-toggle-group"
+  [value]="current()"
+  (change)="change($event.value)"
+  hideSingleSelectionIndicator
+  [attr.aria-label]="'language.label' | translate"
+>
+  @for (lang of languages(); track lang) {
+    <mat-button-toggle [value]="lang">
+      {{ 'language.' + lang | translate }}
+    </mat-button-toggle>
+  }
+</mat-button-toggle-group>

--- a/src/components/language-switcher/language-switcher.ts
+++ b/src/components/language-switcher/language-switcher.ts
@@ -1,0 +1,58 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  DestroyRef,
+  inject,
+  signal,
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { MatButtonToggleModule } from '@angular/material/button-toggle';
+
+import { TranslatePipe, TranslateService } from '@ngx-translate/core';
+
+export type AppLanguage = 'en' | 'ru';
+
+const LANG_STORAGE_KEY = 'app.lang';
+const SUPPORTED: readonly AppLanguage[] = ['en', 'ru'];
+
+@Component({
+  selector: 'app-language-switcher',
+  imports: [MatButtonToggleModule, TranslatePipe],
+  templateUrl: './language-switcher.html',
+  styleUrl: './language-switcher.css',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class LanguageSwitcher {
+  private readonly translate = inject(TranslateService);
+  private readonly destroyRef = inject(DestroyRef);
+
+  protected readonly current = signal<AppLanguage>(this.resolveInitial());
+  protected readonly languages = computed<readonly AppLanguage[]>(
+    () => SUPPORTED,
+  );
+
+  constructor() {
+    this.translate.addLangs([...SUPPORTED]);
+    this.translate
+      .use(this.current())
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe();
+  }
+
+  protected change(lang: AppLanguage): void {
+    if (lang === this.current()) return;
+    this.current.set(lang);
+    localStorage.setItem(LANG_STORAGE_KEY, lang);
+    this.translate
+      .use(lang)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe();
+  }
+
+  private resolveInitial(): AppLanguage {
+    const saved = localStorage.getItem(LANG_STORAGE_KEY);
+    if (saved === 'en' || saved === 'ru') return saved;
+    return 'en';
+  }
+}

--- a/src/components/toasts/toasts.component.html
+++ b/src/components/toasts/toasts.component.html
@@ -2,7 +2,11 @@
   @for (toast of toasts(); track toast.id) {
     <div class="toast toast--{{ toast.type }}">
       <span class="toast__message">{{ toast.message }}</span>
-      <button class="toast__close" (click)="dismiss(toast.id)" aria-label="Close">×</button>
+      <button
+        class="toast__close"
+        (click)="dismiss(toast.id)"
+        [attr.aria-label]="'toasts.close' | translate"
+      >×</button>
     </div>
   }
 </div>

--- a/src/components/toasts/toasts.component.html
+++ b/src/components/toasts/toasts.component.html
@@ -1,5 +1,5 @@
 <div class="toasts-container">
-  @for (toast of toasts; track toast.id) {
+  @for (toast of toasts(); track toast.id) {
     <div class="toast toast--{{ toast.type }}">
       <span class="toast__message">{{ toast.message }}</span>
       <button class="toast__close" (click)="dismiss(toast.id)" aria-label="Close">×</button>

--- a/src/components/toasts/toasts.component.ts
+++ b/src/components/toasts/toasts.component.ts
@@ -1,30 +1,21 @@
-import { CommonModule } from '@angular/common';
-import { Component, inject,OnDestroy, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
 
-import { Subscription } from 'rxjs';
-
-import { Toast,ToastService } from '../../services/toast.service';
+import { Toast, ToastService } from '../../services/toast.service';
 
 @Component({
   selector: 'app-toasts',
-  imports: [CommonModule],
+  imports: [],
   templateUrl: './toasts.component.html',
   styleUrl: './toasts.component.css',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class Toasts implements OnInit, OnDestroy {
-  private toastService = inject(ToastService);
-  toasts: Toast[] = [];
-  private subscription?: Subscription;
+export class Toasts {
+  private readonly toastService = inject(ToastService);
 
-  ngOnInit(): void {
-    this.subscription = this.toastService.toasts$.subscribe(
-      (toasts) => (this.toasts = toasts),
-    );
-  }
-
-  ngOnDestroy(): void {
-    this.subscription?.unsubscribe();
-  }
+  protected readonly toasts = toSignal(this.toastService.toasts$, {
+    initialValue: [] as Toast[],
+  });
 
   dismiss(id: number): void {
     this.toastService.removeToast(id);

--- a/src/components/toasts/toasts.component.ts
+++ b/src/components/toasts/toasts.component.ts
@@ -1,11 +1,13 @@
 import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 
+import { TranslatePipe } from '@ngx-translate/core';
+
 import { Toast, ToastService } from '../../services/toast.service';
 
 @Component({
   selector: 'app-toasts',
-  imports: [],
+  imports: [TranslatePipe],
   templateUrl: './toasts.component.html',
   styleUrl: './toasts.component.css',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/src/components/todo-create-item/todo-create-item.html
+++ b/src/components/todo-create-item/todo-create-item.html
@@ -3,19 +3,21 @@
     class="task-input"
     formControlName="name"
     type="text"
-    placeholder="Task name"
+    [placeholder]="'createTask.namePlaceholder' | translate"
+    [attr.aria-label]="'createTask.namePlaceholder' | translate"
   />
 
   <textarea
     class="task-input task-textarea"
     formControlName="description"
-    placeholder="Task description"
+    [placeholder]="'createTask.descriptionPlaceholder' | translate"
+    [attr.aria-label]="'createTask.descriptionPlaceholder' | translate"
   ></textarea>
 
   <app-button
     type="submit"
-    hintText="Click to add a new task"
+    [hintText]="'createTask.addHint' | translate"
     [isDisabled]="form.invalid"
     className="button button--add"
-  >add</app-button>
+  >{{ 'createTask.addButton' | translate }}</app-button>
 </form>

--- a/src/components/todo-create-item/todo-create-item.ts
+++ b/src/components/todo-create-item/todo-create-item.ts
@@ -1,6 +1,8 @@
 import { ChangeDetectionStrategy, Component, output } from '@angular/core';
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 
+import { TranslatePipe } from '@ngx-translate/core';
+
 import { Button } from '../button/button';
 
 export interface CreateTaskPayload {
@@ -10,7 +12,7 @@ export interface CreateTaskPayload {
 
 @Component({
   selector: 'app-todo-create-item',
-  imports: [ReactiveFormsModule, Button],
+  imports: [ReactiveFormsModule, Button, TranslatePipe],
   templateUrl: './todo-create-item.html',
   styleUrl: './todo-create-item.css',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/src/components/todo-item-view/todo-item-view.html
+++ b/src/components/todo-item-view/todo-item-view.html
@@ -1,17 +1,17 @@
-  <div class="description-panel">
-    <h3 class="description-panel__title">Task Description</h3>
-    @if (task()) {
-    <p class="description-panel__text">{{ task().description }}</p>
-    <label class="description-panel__status">
-      <input
-        type="checkbox"
-        class="description-panel__status-checkbox"
-        [checked]="task().status === 'Completed'"
-        (change)="onStatusChanged($event)"
-      />
-      <span class="description-panel__status-label">Completed</span>
-    </label>
-    } @else {
-    <p class="description-panel__placeholder">Select a task to see its description</p>
-    }
-  </div>
+<div class="description-panel">
+  <h3 class="description-panel__title">{{ 'details.title' | translate }}</h3>
+  @if (task()) {
+  <p class="description-panel__text">{{ task().description }}</p>
+  <label class="description-panel__status">
+    <input
+      type="checkbox"
+      class="description-panel__status-checkbox"
+      [checked]="task().status === 'Completed'"
+      (change)="onStatusChanged($event)"
+    />
+    <span class="description-panel__status-label">{{ 'details.completed' | translate }}</span>
+  </label>
+  } @else {
+  <p class="description-panel__placeholder">{{ 'details.placeholder' | translate }}</p>
+  }
+</div>

--- a/src/components/todo-item-view/todo-item-view.ts
+++ b/src/components/todo-item-view/todo-item-view.ts
@@ -8,6 +8,7 @@ import {
 import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import { ActivatedRoute } from '@angular/router';
 
+import { TranslatePipe } from '@ngx-translate/core';
 import { map } from 'rxjs';
 
 import { TodoService } from '../../services/todo.service';
@@ -15,7 +16,7 @@ import { Task } from '../todo-item/todo-item';
 
 @Component({
   selector: 'app-todo-item-view',
-  imports: [],
+  imports: [TranslatePipe],
   templateUrl: './todo-item-view.html',
   styleUrl: './todo-item-view.css',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/src/components/todo-item/todo-item.html
+++ b/src/components/todo-item/todo-item.html
@@ -13,10 +13,10 @@
       <p class="todo-item__id">{{ task().id }}</p>
       <p class="todo-item__text">{{ task().text }}</p>
       <app-button
-        hintText="Click to remove this task"
+        [hintText]="'todoItem.removeHint' | translate"
         (clicked)="deleteItem.emit()"
         className="button button--delete"
-      >remove</app-button>
+      >{{ 'todoItem.remove' | translate }}</app-button>
     </div>
   }
 
@@ -34,11 +34,11 @@
       <app-button
         (clicked)="saveEdit()"
         className="button button--save"
-      >save</app-button>
+      >{{ 'todoItem.save' | translate }}</app-button>
       <app-button
         (clicked)="onCancelEdit()"
         className="button button--cancel"
-      >cancel</app-button>
+      >{{ 'todoItem.cancel' | translate }}</app-button>
     </div>
   }
 </li>

--- a/src/components/todo-item/todo-item.ts
+++ b/src/components/todo-item/todo-item.ts
@@ -1,6 +1,8 @@
 import { Component, input, output, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 
+import { TranslatePipe } from '@ngx-translate/core';
+
 import { ShowHintOnHoverDirective } from '../../shared/show-hint-on-hover.directive';
 import { Button } from '../button/button';
 
@@ -16,7 +18,7 @@ export interface Task {
 
 @Component({
   selector: 'app-todo-item',
-  imports: [Button, ShowHintOnHoverDirective, FormsModule],
+  imports: [Button, ShowHintOnHoverDirective, FormsModule, TranslatePipe],
   templateUrl: './todo-item.html',
   styleUrl: './todo-item.css',
 })

--- a/src/services/toast.service.ts
+++ b/src/services/toast.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 
-import { BehaviorSubject, Observable } from 'rxjs';
+import { BehaviorSubject, Observable, Subject, timer } from 'rxjs';
+import { filter, takeUntil } from 'rxjs/operators';
 
 export interface Toast {
   id: number;
@@ -13,14 +14,20 @@ export interface Toast {
   providedIn: 'root',
 })
 export class ToastService {
-  private toastsSubject = new BehaviorSubject<Toast[]>([]);
-  toasts$: Observable<Toast[]> = this.toastsSubject.asObservable();
+  private readonly _toasts$ = new BehaviorSubject<Toast[]>([]);
+  private readonly removed$ = new Subject<number>();
+
+  readonly toasts$: Observable<Toast[]> = this._toasts$.asObservable();
 
   private nextId = 1;
 
+  get toasts(): Toast[] {
+    return this._toasts$.value;
+  }
+
   showToast(
     message: string,
-    type: 'success' | 'info' | 'warning' | 'error' = 'info',
+    type: Toast['type'] = 'info',
     duration = 3000,
   ): void {
     const toast: Toast = {
@@ -29,18 +36,16 @@ export class ToastService {
       type,
       duration,
     };
+    this._toasts$.next([...this._toasts$.value, toast]);
 
-    const currentToasts = this.toastsSubject.value;
-    this.toastsSubject.next([...currentToasts, toast]);
-
-    // Auto-dismiss after duration
-    setTimeout(() => {
-      this.removeToast(toast.id);
-    }, duration);
+    timer(duration)
+      .pipe(takeUntil(this.removed$.pipe(filter((id) => id === toast.id))))
+      .subscribe(() => this.removeToast(toast.id));
   }
 
   removeToast(id: number): void {
-    const currentToasts = this.toastsSubject.value;
-    this.toastsSubject.next(currentToasts.filter((t) => t.id !== id));
+    if (!this._toasts$.value.some((t) => t.id === id)) return;
+    this._toasts$.next(this._toasts$.value.filter((t) => t.id !== id));
+    this.removed$.next(id);
   }
 }

--- a/src/services/todo.service.ts
+++ b/src/services/todo.service.ts
@@ -1,7 +1,7 @@
 import { inject, Injectable, signal } from '@angular/core';
 
 import { BehaviorSubject, combineLatest, EMPTY, Observable, of } from 'rxjs';
-import { catchError, map, tap } from 'rxjs/operators';
+import { catchError, finalize, map, tap } from 'rxjs/operators';
 
 import { Task, TaskStatus } from '../components/todo-item/todo-item';
 import { ServerTask, TaskApiService } from './task-api.service';
@@ -26,23 +26,13 @@ export class TodoService {
     ),
   );
 
-  get tasks(): Task[] {
-    const selectedId = this.selectedId$.value;
-    return this._tasks$.value.map((t) => ({
-      ...t,
-      isSelected: t.id === selectedId,
-    }));
-  }
-
   loadTasks(): Observable<ServerTask[]> {
     this.isLoading.set(true);
     return this.apiService.getAll().pipe(
       map((tasks) => tasks.map((t) => ({ ...t, id: Number(t.id) }))),
       catchError(() => of([] as ServerTask[])),
-      tap((tasks) => {
-        this._tasks$.next(tasks);
-        this.isLoading.set(false);
-      }),
+      tap((tasks) => this._tasks$.next(tasks)),
+      finalize(() => this.isLoading.set(false)),
     );
   }
 

--- a/src/services/todo.service.ts
+++ b/src/services/todo.service.ts
@@ -1,16 +1,10 @@
 import { inject, Injectable, signal } from '@angular/core';
 
-import {
-  BehaviorSubject,
-  combineLatest,
- EMPTY, Observable,
-  of,
-  switchMap,
-} from 'rxjs';
-import { catchError, map, shareReplay, tap } from 'rxjs/operators';
+import { BehaviorSubject, combineLatest, EMPTY, Observable, of } from 'rxjs';
+import { catchError, map, tap } from 'rxjs/operators';
 
 import { Task, TaskStatus } from '../components/todo-item/todo-item';
-import { ServerTask,TaskApiService } from './task-api.service';
+import { ServerTask, TaskApiService } from './task-api.service';
 
 @Injectable({
   providedIn: 'root',
@@ -18,39 +12,49 @@ import { ServerTask,TaskApiService } from './task-api.service';
 export class TodoService {
   private apiService = inject(TaskApiService);
 
-  private refresh$ = new BehaviorSubject<void>(undefined);
-  private selectedId$ = new BehaviorSubject<number | null>(null);
+  private readonly _tasks$ = new BehaviorSubject<ServerTask[]>([]);
+  private readonly selectedId$ = new BehaviorSubject<number | null>(null);
 
-  readonly isLoading = signal(true);
+  readonly isLoading = signal(false);
 
-  private serverTasks$ = this.refresh$.pipe(
-    tap(() => this.isLoading.set(true)),
-    switchMap(() =>
-      this.apiService.getAll().pipe(
-        map((tasks) => tasks.map((t) => ({ ...t, id: Number(t.id) }))),
-        catchError(() => of([] as ServerTask[])),
-      ),
-    ),
-    tap(() => this.isLoading.set(false)),
-    shareReplay({ bufferSize: 1, refCount: true }),
-  );
-
-  tasks$: Observable<Task[]> = combineLatest([
-    this.serverTasks$,
+  readonly tasks$: Observable<Task[]> = combineLatest([
+    this._tasks$,
     this.selectedId$,
   ]).pipe(
     map(([tasks, selectedId]) =>
       tasks.map((t) => ({ ...t, isSelected: t.id === selectedId })),
     ),
-    shareReplay({ bufferSize: 1, refCount: true }),
   );
+
+  get tasks(): Task[] {
+    const selectedId = this.selectedId$.value;
+    return this._tasks$.value.map((t) => ({
+      ...t,
+      isSelected: t.id === selectedId,
+    }));
+  }
+
+  loadTasks(): Observable<ServerTask[]> {
+    this.isLoading.set(true);
+    return this.apiService.getAll().pipe(
+      map((tasks) => tasks.map((t) => ({ ...t, id: Number(t.id) }))),
+      catchError(() => of([] as ServerTask[])),
+      tap((tasks) => {
+        this._tasks$.next(tasks);
+        this.isLoading.set(false);
+      }),
+    );
+  }
 
   addTask(text: string, description: string): Observable<ServerTask> {
     const value = text.trim();
     if (!value) return EMPTY;
-    return this.apiService
-      .create(value, description)
-      .pipe(tap(() => this.refresh$.next()));
+    return this.apiService.create(value, description).pipe(
+      tap((created) => {
+        const next = { ...created, id: Number(created.id) };
+        this._tasks$.next([...this._tasks$.value, next]);
+      }),
+    );
   }
 
   updateTask(id: number, text: string): Observable<ServerTask> {
@@ -58,20 +62,31 @@ export class TodoService {
     if (!value) return EMPTY;
     return this.apiService
       .update(id, { text: value })
-      .pipe(tap(() => this.refresh$.next()));
+      .pipe(tap((updated) => this.patchLocal(id, updated)));
   }
 
   deleteTask(id: number): Observable<void> {
-    return this.apiService.delete(id).pipe(tap(() => this.refresh$.next()));
+    return this.apiService.delete(id).pipe(
+      tap(() =>
+        this._tasks$.next(this._tasks$.value.filter((t) => t.id !== id)),
+      ),
+    );
   }
 
   updateTaskStatus(id: number, status: TaskStatus): Observable<ServerTask> {
     return this.apiService
       .update(id, { status })
-      .pipe(tap(() => this.refresh$.next()));
+      .pipe(tap((updated) => this.patchLocal(id, updated)));
   }
 
   selectTask(taskId: number): void {
     this.selectedId$.next(taskId);
+  }
+
+  private patchLocal(id: number, updated: ServerTask): void {
+    const next = this._tasks$.value.map((t) =>
+      t.id === id ? { ...t, ...updated, id: Number(updated.id) } : t,
+    );
+    this._tasks$.next(next);
   }
 }


### PR DESCRIPTION
## Summary
- Подключил `@ngx-translate/core` v17 + `@ngx-translate/http-loader` через `provideTranslateService` (standalone API).
- Все UI-строки вынесены в `public/i18n/en.json` и `public/i18n/ru.json`.
- Добавил компонент `LanguageSwitcher` (mat-button-toggle) в верхнем header справа; выбор языка сохраняется в `localStorage`.
- Тосты в `Backlog` переведены через `TranslateService.instant()`.
- Язык по умолчанию — английский, переключение между EN ↔ RU работает на лету без перезагрузки.